### PR TITLE
Add getEfieldsNormalMode: fchk parsing, Kabsch alignment, normal mode…

### DIFF
--- a/pyef/__init__.py
+++ b/pyef/__init__.py
@@ -1,3 +1,7 @@
 """A package for calculating electric fields and electrostatics in molecular systems."""
 
 from ._version import __version__
+from .fchk_interface import parse_geometry, parse_normal_modes, get_mode, detect_format
+from .normal_mode import (kabsch_rotation, align_to_reference,
+                          project_efield_onto_mode, per_atom_efield_from_charges,
+                          get_heavy_atom_indices)

--- a/pyef/analysis.py
+++ b/pyef/analysis.py
@@ -4987,6 +4987,239 @@ Please verify the file exists or set the path to None for jobs without point cha
         return df
     
 
+    # -----------------------------------------------------------------------
+    def getEfieldsNormalMode(self,
+                             fchk_path,
+                             mode_index,
+                             output_filename,
+                             multiwfn_path,
+                             n_solute,
+                             charge_type='CM5',
+                             mode_vectors=None,
+                             align_heavy_only=True,
+                             dielectric_scale=1.0):
+        """Project the environmental electric field onto a vibrational normal mode.
+
+        Computes the Vibrational Stark Effect (VSE) field:
+
+            F_mode = Σ_i  F_i · (R @ L_i)
+
+        where F_i is the Coulomb field at solute atom i from the environment
+        (QM solvent charges + MM point charges if QM/MM), L_i is the normal
+        mode displacement vector, and R is the Kabsch rotation that aligns the
+        QM reference geometry (from fchk) to each frame's optimised geometry.
+
+        Supports three calculation modes depending on how the Electrostatics
+        object was constructed:
+
+        * **Pure QM** — only molden files, no point charges
+        * **QM/MM**   — molden files + MM point charges (via ptchg_paths /
+          includePtChgs)
+        * **Reuse existing charges** — if ``Charges{charge_type}.txt`` already
+          exists in each job folder (e.g. from a previous ``getEfield`` run),
+          Multiwfn is skipped for that frame.
+
+        Parameters
+        ----------
+        fchk_path : str
+            Path to the ``.fchk`` file.
+
+            * **Gaussian** format: geometry + normal modes are read directly;
+              ``mode_vectors`` is ignored.
+            * **Q-Chem** format: only reference geometry is read; you must
+              supply ``mode_vectors``.
+
+        mode_index : int
+            1-based mode number (as labelled by Q-Chem / Gaussian output).
+
+        output_filename : str
+            Stem for the output CSV (extension ``.csv`` is added if absent).
+
+        multiwfn_path : str
+            Path to the Multiwfn executable.
+
+        n_solute : int
+            Number of solute atoms (first *n_solute* rows of each charge file
+            are treated as the molecule of interest; the rest are environment).
+
+        charge_type : str, optional
+            Charge partitioning scheme (default ``'CM5'``).
+
+        mode_vectors : np.ndarray or None, optional
+            Normal mode displacement array, shape ``(n_modes, n_atoms, 3)`` or
+            ``(n_atoms, 3)`` for a single mode.  Required for Q-Chem fchk;
+            ignored for Gaussian fchk.
+
+        align_heavy_only : bool, optional
+            If ``True`` (default), use only non-hydrogen atoms for the Kabsch
+            alignment (more stable; avoids H-atom positional noise).
+
+        dielectric_scale : float, optional
+            Scale factor applied to MM point charges (default 1.0).  Set to
+            ``1/epsilon`` for implicit-solvent screening of the MM region.
+
+        Returns
+        -------
+        pd.DataFrame
+            Columns: ``job``, ``F_mode_VA`` (V/Å), ``F_mode_MV_cm``
+            (MV/cm = 100 × V/Å), plus ``freq_cm1`` if read from Gaussian fchk.
+
+        Output Files
+        ------------
+        ``{output_filename}.csv`` — one row per job.
+
+        Examples
+        --------
+        Pure QM (Gaussian fchk, mode from fchk):
+
+        >>> es = Electrostatics(molden_paths, xyz_paths)
+        >>> es.prepData()
+        >>> df = es.getEfieldsNormalMode(
+        ...     fchk_path='freq.fchk',
+        ...     mode_index=33,
+        ...     output_filename='nm_ef_CM5',
+        ...     multiwfn_path='/path/to/Multiwfn',
+        ...     n_solute=15,
+        ... )
+
+        QM/MM (Q-Chem fchk, mode vectors supplied):
+
+        >>> es = Electrostatics(molden_paths, xyz_paths, ptchg_paths=ptchg_list)
+        >>> es.prepData()
+        >>> df = es.getEfieldsNormalMode(
+        ...     fchk_path='freq.fchk',
+        ...     mode_index=33,
+        ...     output_filename='nm_ef_QMMMmode33',
+        ...     multiwfn_path='/path/to/Multiwfn',
+        ...     n_solute=15,
+        ...     mode_vectors=PZQ_MODE33,   # (n_atoms, 3) array
+        ... )
+        """
+        import pandas as pd
+        from .fchk_interface import parse_geometry, get_mode, detect_format
+        from .normal_mode import (get_heavy_atom_indices,
+                                  align_to_reference,
+                                  project_efield_onto_mode,
+                                  per_atom_efield_from_charges)
+
+        # ── 1. Parse reference geometry and mode vector from fchk ────────────
+        atomic_numbers, ref_coords = parse_geometry(fchk_path)
+
+        if len(atomic_numbers) != n_solute:
+            raise ValueError(
+                f"fchk has {len(atomic_numbers)} atoms but n_solute={n_solute}. "
+                "The fchk should contain only the solute molecule."
+            )
+
+        freq, mode_vec = get_mode(fchk_path, mode_index, mode_vectors)
+        mode_vec = np.asarray(mode_vec, dtype=float)   # (n_solute, 3)
+
+        align_idx = (get_heavy_atom_indices(atomic_numbers)
+                     if align_heavy_only else np.arange(n_solute))
+
+        fmt = detect_format(fchk_path)
+        freq_label = f"{freq:.2f}" if freq is not None else "user-supplied"
+        print(f"\n{'='*60}")
+        print(f"getEfieldsNormalMode")
+        print(f"  fchk format  : {fmt}")
+        print(f"  mode index   : {mode_index}  (freq = {freq_label} cm⁻¹)")
+        print(f"  n_solute     : {n_solute}")
+        print(f"  charge_type  : {charge_type}")
+        print(f"  jobs         : {len(self.lst_of_folders)}")
+        print(f"{'='*60}\n")
+
+        # ── 2. Ensure charge files exist (run Multiwfn if needed) ────────────
+        owd = os.getcwd()
+        for idx, folder in enumerate(self.lst_of_folders):
+            folder = str(folder)
+            charge_file = os.path.join(folder, f"Charges{charge_type}.txt")
+            if os.path.exists(charge_file):
+                continue
+            # Need to run Multiwfn for this job
+            molden_path = self.molden_paths[idx]
+            os.chdir(folder)
+            try:
+                self.multiwfn.getCharges(charge_type, molden_path, multiwfn_path)
+            finally:
+                os.chdir(owd)
+
+        # ── 3. Process each job ──────────────────────────────────────────────
+        records = []
+        for idx, folder in enumerate(self.lst_of_folders):
+            folder = str(folder)
+            charge_file = os.path.join(folder, f"Charges{charge_type}.txt")
+
+            if not os.path.exists(charge_file):
+                print(f"  WARNING: charge file missing for {folder}, skipping.")
+                continue
+
+            # Load QM region charges (element  x  y  z  charge)
+            df_chg = pd.read_csv(
+                charge_file, sep=r'\s+',
+                names=['element', 'x', 'y', 'z', 'charge']
+            )
+            coords  = df_chg[['x', 'y', 'z']].values.astype(float)   # (n_qm, 3)
+            charges = df_chg['charge'].values.astype(float)            # (n_qm,)
+
+            solute_coords  = coords[:n_solute]
+            env_coords_qm  = coords[n_solute:]
+            env_charges_qm = charges[n_solute:]
+
+            # Optional MM point charges
+            env_coords_mm  = np.empty((0, 3))
+            env_charges_mm = np.empty(0)
+
+            ptchg_path = self._get_ptchg_path_for_job(idx, folder)
+            if ptchg_path is not None and os.path.exists(ptchg_path):
+                df_mm = self.getPtChgs(ptchg_path)
+                env_coords_mm  = df_mm[['x', 'y', 'z']].values.astype(float)
+                env_charges_mm = df_mm['charge'].values.astype(float) * dielectric_scale
+
+            # Combine QM-environment + MM
+            if len(env_coords_mm):
+                env_coords  = np.vstack([env_coords_qm,  env_coords_mm])
+                env_charges = np.concatenate([env_charges_qm, env_charges_mm])
+            else:
+                env_coords  = env_coords_qm
+                env_charges = env_charges_qm
+
+            # Kabsch rotation: align fchk reference solute → current solute
+            R = align_to_reference(solute_coords, ref_coords, align_idx)
+
+            # Per-atom E-field at each solute atom from environment (V/Å)
+            F_atoms = per_atom_efield_from_charges(
+                solute_coords, env_coords, env_charges
+            )
+
+            # Project onto normal mode
+            F_mode = project_efield_onto_mode(F_atoms, mode_vec, R)
+
+            records.append({
+                'job':        folder,
+                'freq_cm1':   freq,
+                'F_mode_VA':  F_mode,
+                'F_mode_MV_cm': F_mode * 100.0,   # V/Å → MV/cm
+            })
+
+            if (idx + 1) % 10 == 0 or (idx + 1) == len(self.lst_of_folders):
+                print(f"  {idx+1}/{len(self.lst_of_folders)}  "
+                      f"F_mode = {F_mode:.4f} V/Å  ({F_mode*100:.2f} MV/cm)")
+
+        df_out = pd.DataFrame(records)
+
+        # ── 4. Save CSV ──────────────────────────────────────────────────────
+        if not output_filename.endswith('.csv'):
+            output_filename += '.csv'
+        df_out.to_csv(output_filename, index=False)
+        print(f"\nSaved {len(df_out)} results to {output_filename}")
+
+        if len(df_out):
+            mean_f = df_out['F_mode_MV_cm'].mean()
+            std_f  = df_out['F_mode_MV_cm'].std()
+            print(f"  F_mode: {mean_f:.3f} ± {std_f:.3f} MV/cm")
+
+        return df_out
+
 
 def visualize_charges_pdb(xyz_file, charges, pdb_name):
     """Create a PDB file with charges visualized in the b-factor column.

--- a/pyef/fchk_interface.py
+++ b/pyef/fchk_interface.py
@@ -1,0 +1,190 @@
+"""
+Parser for formatted checkpoint (.fchk) files.
+
+Supports:
+  - Gaussian fchk: geometry + normal modes + frequencies
+  - Q-Chem fchk:   geometry only (no Vib-Modes section)
+
+Auto-detection: if 'Vib-Modes' section is present → Gaussian format.
+
+All coordinates are returned in Angstroms (fchk stores Bohr).
+Normal mode eigenvectors are returned as (n_modes, n_atoms, 3) arrays,
+already mass-weighted and normalized as printed by the QM code.
+"""
+
+import numpy as np
+
+BOHR_TO_ANG = 0.529177210903
+
+
+def _read_section(lines, key):
+    """
+    Return (header_line, flat_list_of_values) for the first section whose
+    header starts with `key`.  Returns (None, None) if not found.
+    """
+    for i, line in enumerate(lines):
+        if line.startswith(key):
+            header = line.rstrip()
+            # scalar value on the same line?
+            parts = header.split()
+            if parts[-2] in ('I', 'R', 'C', 'L') and parts[-1] not in ('N=',):
+                # scalar: value is last token (no continuation block)
+                try:
+                    return header, [parts[-1]]
+                except Exception:
+                    return header, []
+            # array: read until next header-like line
+            values = []
+            j = i + 1
+            while j < len(lines):
+                nxt = lines[j]
+                # header lines start with a letter and contain type codes
+                if (nxt and nxt[0].isalpha() and
+                        any(f' {t} ' in nxt for t in (' I ', ' R ', ' C ', ' L '))):
+                    break
+                values.extend(nxt.split())
+                j += 1
+            return header, values
+    return None, None
+
+
+def _parse_int_array(values):
+    return [int(v) for v in values]
+
+
+def _parse_float_array(values):
+    return [float(v.replace('D', 'E').replace('d', 'e')) for v in values]
+
+
+def detect_format(fchk_path):
+    """Return 'gaussian' if Vib-Modes section present, else 'qchem'."""
+    with open(fchk_path) as f:
+        for line in f:
+            if line.startswith('Vib-Modes'):
+                return 'gaussian'
+    return 'qchem'
+
+
+def parse_geometry(fchk_path):
+    """
+    Parse reference geometry from fchk (Gaussian or Q-Chem).
+
+    Returns
+    -------
+    atomic_numbers : np.ndarray  shape (n_atoms,)  int
+    coords         : np.ndarray  shape (n_atoms, 3) float, Angstroms
+    """
+    with open(fchk_path) as f:
+        lines = f.readlines()
+
+    _, anum_vals = _read_section(lines, 'Atomic numbers')
+    _, coord_vals = _read_section(lines, 'Current cartesian coordinates')
+
+    if anum_vals is None or coord_vals is None:
+        raise ValueError(f"Could not find geometry sections in {fchk_path}")
+
+    atomic_numbers = np.array(_parse_int_array(anum_vals), dtype=int)
+    coords_bohr    = np.array(_parse_float_array(coord_vals), dtype=float)
+    n_atoms        = len(atomic_numbers)
+
+    if len(coords_bohr) != 3 * n_atoms:
+        raise ValueError(
+            f"Coordinate count mismatch: expected {3*n_atoms}, got {len(coords_bohr)}"
+        )
+
+    coords = coords_bohr.reshape(n_atoms, 3) * BOHR_TO_ANG
+    return atomic_numbers, coords
+
+
+def parse_normal_modes(fchk_path):
+    """
+    Parse normal mode frequencies and eigenvectors from a **Gaussian** fchk.
+
+    Returns
+    -------
+    frequencies : np.ndarray  shape (n_modes,)        cm⁻¹
+    modes       : np.ndarray  shape (n_modes, n_atoms, 3)
+                  Each row is one normalised eigenvector in Cartesian space.
+
+    Raises
+    ------
+    ValueError  if the file is Q-Chem format (no Vib-Modes section).
+    """
+    if detect_format(fchk_path) != 'gaussian':
+        raise ValueError(
+            f"{fchk_path} appears to be Q-Chem format — no Vib-Modes section.\n"
+            "Pass mode vectors directly via the `mode_vectors` argument."
+        )
+
+    with open(fchk_path) as f:
+        lines = f.readlines()
+
+    _, natom_vals = _read_section(lines, 'Number of atoms')
+    n_atoms = int(natom_vals[0])
+
+    _, freq_vals = _read_section(lines, 'Vib-Freq')
+    if freq_vals is None:
+        raise ValueError("No 'Vib-Freq' section found in fchk.")
+    frequencies = np.array(_parse_float_array(freq_vals), dtype=float)
+    n_modes = len(frequencies)
+
+    _, mode_vals = _read_section(lines, 'Vib-Modes')
+    if mode_vals is None:
+        raise ValueError("No 'Vib-Modes' section found in fchk.")
+    mode_flat = np.array(_parse_float_array(mode_vals), dtype=float)
+
+    # Gaussian stores modes column-major: all atoms for mode 0, then mode 1, …
+    # Total elements = n_modes * 3 * n_atoms
+    if len(mode_flat) != n_modes * 3 * n_atoms:
+        raise ValueError(
+            f"Vib-Modes size mismatch: expected {n_modes * 3 * n_atoms}, "
+            f"got {len(mode_flat)}"
+        )
+    modes = mode_flat.reshape(n_modes, n_atoms, 3)
+    return frequencies, modes
+
+
+def get_mode(fchk_path, mode_index, mode_vectors=None):
+    """
+    Retrieve a single normal mode vector.
+
+    Parameters
+    ----------
+    fchk_path    : str   path to .fchk file
+    mode_index   : int   1-based mode number (as printed by Q-Chem / Gaussian)
+    mode_vectors : np.ndarray or None
+        If provided, shape (n_modes, n_atoms, 3) or (n_atoms, 3).
+        Required for Q-Chem fchk; ignored for Gaussian fchk.
+
+    Returns
+    -------
+    freq   : float or None   frequency in cm⁻¹ (None for Q-Chem)
+    vector : np.ndarray      shape (n_atoms, 3)  normalised displacement
+    """
+    fmt = detect_format(fchk_path)
+
+    if fmt == 'gaussian':
+        frequencies, modes = parse_normal_modes(fchk_path)
+        idx = mode_index - 1   # convert to 0-based
+        if idx < 0 or idx >= len(frequencies):
+            raise IndexError(
+                f"mode_index {mode_index} out of range (1–{len(frequencies)})"
+            )
+        return float(frequencies[idx]), modes[idx]
+
+    else:  # Q-Chem: no Vib-Modes in fchk
+        if mode_vectors is None:
+            raise ValueError(
+                "Q-Chem fchk has no normal mode data. "
+                "Pass mode_vectors as a (n_modes, n_atoms, 3) array."
+            )
+        mv = np.asarray(mode_vectors, dtype=float)
+        if mv.ndim == 2:
+            # Single mode passed directly
+            return None, mv
+        idx = mode_index - 1
+        if idx < 0 or idx >= len(mv):
+            raise IndexError(
+                f"mode_index {mode_index} out of range (1–{len(mv)})"
+            )
+        return None, mv[idx]

--- a/pyef/normal_mode.py
+++ b/pyef/normal_mode.py
@@ -1,0 +1,163 @@
+"""
+Normal mode electric field projection utilities.
+
+Provides Kabsch alignment and projection of per-atom electric field vectors
+onto a normal mode eigenvector.
+
+The projected field is:
+
+    F_mode = Σ_i  F_i · (R @ L_i)
+
+where:
+    F_i  : electric field vector at solute atom i  (V/Å, shape (3,))
+    L_i  : QM normal mode displacement for atom i  (shape (3,))
+    R    : 3×3 Kabsch rotation mapping the QM reference frame to the
+           current molecular frame
+
+This is the standard Stark-tuning projection used in vibrational Stark
+effect spectroscopy.
+"""
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Heavy-atom element sets (for auto-selecting alignment atoms)
+# ---------------------------------------------------------------------------
+_HEAVY_ATOM_NUMBERS = set(range(3, 119))   # everything except H (1) and He (2)
+
+
+def get_heavy_atom_indices(atomic_numbers):
+    """Return 0-based indices of non-hydrogen atoms."""
+    return np.array([i for i, z in enumerate(atomic_numbers) if z > 1], dtype=int)
+
+
+# ---------------------------------------------------------------------------
+# Kabsch rotation
+# ---------------------------------------------------------------------------
+
+def kabsch_rotation(P, Q):
+    """
+    Find the rotation matrix R that best superposes P onto Q (both centred).
+
+    Parameters
+    ----------
+    P, Q : np.ndarray  shape (N, 3)  — must already be mean-centred
+
+    Returns
+    -------
+    R : np.ndarray  shape (3, 3)
+        Rotation such that  Q_approx = P @ R.T  (i.e. R @ p_i ≈ q_i).
+    """
+    H = P.T @ Q
+    U, _, Vt = np.linalg.svd(H)
+    # Correct for improper rotation (reflection)
+    d = np.linalg.det(Vt.T @ U.T)
+    D = np.diag([1.0, 1.0, d])
+    R = Vt.T @ D @ U.T
+    return R
+
+
+def align_to_reference(current_coords, ref_coords, align_indices=None):
+    """
+    Compute the Kabsch rotation R that maps the QM reference geometry
+    onto the current (MD/QM cluster) geometry.
+
+    Parameters
+    ----------
+    current_coords : np.ndarray  shape (n_atoms, 3)   current frame coords
+    ref_coords     : np.ndarray  shape (n_atoms, 3)   QM reference coords (Å)
+    align_indices  : array-like or None
+        Atom indices used for the fit (default: all atoms).
+
+    Returns
+    -------
+    R : np.ndarray  shape (3, 3)
+        Rotation mapping QM frame → current frame.
+    """
+    if align_indices is None:
+        align_indices = np.arange(len(ref_coords))
+    align_indices = np.asarray(align_indices)
+
+    P = ref_coords[align_indices]
+    Q = current_coords[align_indices]
+
+    P_c = P - P.mean(axis=0)
+    Q_c = Q - Q.mean(axis=0)
+
+    return kabsch_rotation(P_c, Q_c)
+
+
+# ---------------------------------------------------------------------------
+# Normal-mode projection
+# ---------------------------------------------------------------------------
+
+def project_efield_onto_mode(per_atom_efields, mode_vector, rotation):
+    """
+    Project per-atom electric field vectors onto a (rotated) normal mode.
+
+    Parameters
+    ----------
+    per_atom_efields : np.ndarray  shape (n_solute, 3)
+        Electric field at each solute atom from the environment (V/Å).
+    mode_vector      : np.ndarray  shape (n_solute, 3)
+        Normal mode displacement eigenvector in the QM reference frame.
+    rotation         : np.ndarray  shape (3, 3)
+        Kabsch rotation R mapping QM reference frame → current frame.
+
+    Returns
+    -------
+    F_mode : float   projected field in V/Å
+    """
+    # Rotate each mode displacement vector into the current molecular frame
+    L_rotated = mode_vector @ rotation.T   # (n_solute, 3)
+    # Dot product summed over all solute atoms
+    return float(np.sum(per_atom_efields * L_rotated))
+
+
+# ---------------------------------------------------------------------------
+# Per-atom electric field from point charges (monopole Coulomb)
+# ---------------------------------------------------------------------------
+
+_K_E = 8.987551e9    # N·m²/C²
+_C_E = 1.6023e-19    # C
+_A2M = 1e-10         # Å → m
+
+
+def _minimum_image(r, box):
+    """Minimum image convention; r (...,3), box (3,)."""
+    return r - box * np.round(r / box)
+
+
+def per_atom_efield_from_charges(solute_coords, env_coords, env_charges,
+                                  box=None):
+    """
+    Compute the Coulomb electric field at each solute atom from environment.
+
+    Parameters
+    ----------
+    solute_coords : np.ndarray  shape (n_solute, 3)   Å
+    env_coords    : np.ndarray  shape (n_env, 3)       Å
+    env_charges   : np.ndarray  shape (n_env,)         elementary charge units
+    box           : np.ndarray  shape (3,) or None
+        Periodic box lengths in Å.  None → no PBC.
+
+    Returns
+    -------
+    efields : np.ndarray  shape (n_solute, 3)   V/Å
+    """
+    efields = np.zeros_like(solute_coords)
+    for i, pos in enumerate(solute_coords):
+        r = pos[np.newaxis, :] - env_coords           # (n_env, 3) in Å
+        if box is not None:
+            r = _minimum_image(r, box)
+        r_m  = r * _A2M                               # Å → m
+        d_m  = np.linalg.norm(r_m, axis=1, keepdims=True)
+        mask = d_m[:, 0] > 0
+        E = np.sum(
+            _K_E * _C_E * env_charges[mask, np.newaxis]
+            * r_m[mask] / d_m[mask] ** 3,
+            axis=0
+        ) * _A2M                                      # V/m → V/Å
+        efields[i] = E
+    return efields


### PR DESCRIPTION
… projection

New modules:
- fchk_interface.py: parse geometry/modes from Gaussian or Q-Chem fchk files
- normal_mode.py: Kabsch rotation, per-atom E-field, normal mode projection

New method Electrostatics.getEfieldsNormalMode():
- Supports pure QM, QM/MM, and reuse of existing charge files
- Gaussian fchk: auto-reads Vib-Modes and Vib-Freq
- Q-Chem fchk: reads geometry only; user supplies mode vectors as array
- Tested across all 6 conditions (QM, QM/MM, MM-only x bond + normal mode)

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go